### PR TITLE
#23 Call Menu Irregularities

### DIFF
--- a/radio/static/radio/js/trunkplayer.js
+++ b/radio/static/radio/js/trunkplayer.js
@@ -179,7 +179,7 @@ var last_ajax;
 
 function buildpage() {
     console.log("In build page running : " + buildpage_running + ", live_update " + live_update);
-    if(buildpage_running == 1 || live_update === 0) {
+    if(buildpage_running == 1 || live_update == 0) {
        return false;
     }
     buildpage_running = 1;

--- a/radio/static/radio/js/trunkplayer.js
+++ b/radio/static/radio/js/trunkplayer.js
@@ -452,10 +452,9 @@ $(document).ready(function(){
     // Disable updating when a transmission menu is clicked, reenable after 5 second timeout
     $(document).on('click', 'a.tran-menu-a', function() {
         live_update = 0;
-        $(this).click(); // Try to resolve the occasional need to click twice if the first click falls mid refresh
-        setTimeout(function() {
+                setTimeout(function() {
             live_update = 1;
-            //buildpage();
+            buildpage();
         },5000);
     });
 });

--- a/radio/static/radio/js/trunkplayer.js
+++ b/radio/static/radio/js/trunkplayer.js
@@ -450,9 +450,9 @@ $(document).ready(function(){
     //first_load = 0;
 
     // Disable updating when a transmission menu is clicked, reenable after 5 second timeout
-    $('.tran-menu-a').click(function () {
+    $('.tran-menu-a').click(function() {
         live_update = 0;
-        setTimeout(function () {
+        setTimeout(function() {
             live_update = 1;
             buildpage();
         },5000);

--- a/radio/static/radio/js/trunkplayer.js
+++ b/radio/static/radio/js/trunkplayer.js
@@ -179,7 +179,7 @@ var last_ajax;
 
 function buildpage() {
     console.log("In build page running : " + buildpage_running);
-    if(buildpage_running == 1) {
+    if(buildpage_running == 1 || live_update === 0) {
        return false;
     }
     buildpage_running = 1;
@@ -448,6 +448,14 @@ $(document).ready(function(){
     update_menu();
 
     //first_load = 0;
+
+    // Disable updating when a transmission menu is clicked, reenable after 5 second timeout
+    $('.tran-menu-a').on('click', function () {
+        live_update = 0;
+        setTimeout(function () {
+            live_update = 1;
+        },5000);
+    });
 });
 
 window.onfocus = function() {

--- a/radio/static/radio/js/trunkplayer.js
+++ b/radio/static/radio/js/trunkplayer.js
@@ -178,7 +178,7 @@ function update_menu() {
 var last_ajax;
 
 function buildpage() {
-    console.log("In build page running : " + buildpage_running);
+    console.log("In build page running : " + buildpage_running + ", live_update " + live_update);
     if(buildpage_running == 1 || live_update === 0) {
        return false;
     }
@@ -450,10 +450,11 @@ $(document).ready(function(){
     //first_load = 0;
 
     // Disable updating when a transmission menu is clicked, reenable after 5 second timeout
-    $('.tran-menu-a').on('click', function () {
+    $('.tran-menu-a').click(function () {
         live_update = 0;
         setTimeout(function () {
             live_update = 1;
+            buildpage();
         },5000);
     });
 });

--- a/radio/static/radio/js/trunkplayer.js
+++ b/radio/static/radio/js/trunkplayer.js
@@ -450,11 +450,11 @@ $(document).ready(function(){
     //first_load = 0;
 
     // Disable updating when a transmission menu is clicked, reenable after 5 second timeout
-    $('.tran-menu-a').click(function() {
+    $(document).on('click', 'a.tran-menu-a', function() {
         live_update = 0;
         setTimeout(function() {
             live_update = 1;
-            buildpage();
+            //buildpage();
         },5000);
     });
 });

--- a/radio/static/radio/js/trunkplayer.js
+++ b/radio/static/radio/js/trunkplayer.js
@@ -452,6 +452,7 @@ $(document).ready(function(){
     // Disable updating when a transmission menu is clicked, reenable after 5 second timeout
     $(document).on('click', 'a.tran-menu-a', function() {
         live_update = 0;
+        $(this).click(); // Try to resolve the occasional need to click twice if the first click falls mid refresh
         setTimeout(function() {
             live_update = 1;
             //buildpage();


### PR DESCRIPTION
Interim resolution to #23. Toggles live_update to 0 when a transmission menu is clicked; adds a condition to buildpage() to prevent execution if live_update is 0; resets live_update to 1 after five seconds.