### PR TITLE
Fixing transmission detail template so m4a files can play (and mp3 is not hardcoded)

### DIFF
--- a/radio/templates/radio/transmission_detail.html
+++ b/radio/templates/radio/transmission_detail.html
@@ -70,7 +70,7 @@
 	<div class="row">
 		<div class="col-xs-1"></div>
 		<div class="col-xs-2"><strong>File Name</strong></div>
-		<div class="col-xs-6"><a href="{{object.audio_url}}{{ object.audio_file }}.mp3">{{ object.audio_file }}.mp3</a></div>
+		<div class="col-xs-6"><a href="{{object.audio_url}}{{ object.audio_file }}.{% if object.audio_file_type %}{{ object.audio_file_type }}{% else %}mp3{% endif %}">{{ object.audio_file }}.{% if object.audio_file_type %}{{ object.audio_file_type }}{% else %}mp3{% endif %}</a></div>
 		<div class="col-xs-4"></div>
 	</div>
 	{% endif %}
@@ -79,7 +79,7 @@
                 <div class="col-xs-1"></div>
 		<div class="col-xs-2">
         {% if object.audio_file %}
-<button id="button_{{ object.pk }}" type="button" class="btn play-btn btn-success" onclick="click_play_clip('{{object.audio_url}}{{ object.audio_file }}.{% if audio_file_type %}{{ audio_file_type }}{% else %}mp3{% endif %}', '{{ object.pk }}')"><span class="glyphicon glyphicon-play" aria-hidden="true"></span> Play </button>
+<button id="button_{{ object.pk }}" type="button" class="btn play-btn btn-success" onclick="click_play_clip('{{object.audio_url}}{{ object.audio_file }}.{% if object.audio_file_type %}{{ object.audio_file_type }}{% else %}mp3{% endif %}', '{{ object.pk }}')"><span class="glyphicon glyphicon-play" aria-hidden="true"></span> Play </button>
          {% endif %}
 
 </div>


### PR DESCRIPTION
In the commit https://github.com/ScanOC/trunk-player/commit/af13ecbd773f4f2ab78bd15218c23f93eb7f16d8 the variable `audio_file_type` is used, but there is no such variable, as it's actually a property of the object sent to that template.

Due to this, m4a files do not play on the transmission details page, and the file name still has `.mp3` instead of the actual file type. `object.audio_file_type` should be used to get the file type instead.

This PR updates the template so m4a files can play correctly on the transmission detail page.

Related to https://github.com/ScanOC/trunk-player/pull/36

Thanks for making this awesome player software!