### PR TITLE
Debrand plans page

### DIFF
--- a/radio/templates/radio/plans.html
+++ b/radio/templates/radio/plans.html
@@ -31,7 +31,7 @@
   src="https://checkout.stripe.com/checkout.js" class="stripe-button"
   data-key="{{ stripe_pub_key }}"
   data-amount="{{ plan.stripe_amount }}"
-  data-name="ScanOC.com"
+  data-name="{% get_setting 'SITE_TITLE' %}"
   data-description="{{ plan.stripe_plan.amount }} Plan"
   data-panel-label="Subscribe"
   data-label="Subscribe ${{ plan.stripe_plan.amount }}"


### PR DESCRIPTION
The plans page currently has ScanOC.com hard-coded for Stripe subscriptions. This commit removes the hard-coded name and instead replaces it with the  'SITE_TITLE' setting defined by the end user.