### PR TITLE
Update Prune_database.py

### DIFF
--- a/radio/management/commands/export_talkgroups.py
+++ b/radio/management/commands/export_talkgroups.py
@@ -61,5 +61,5 @@ def export_tg_file(self, options):
             if(t.system_id):
                 systemid = t.system_id
 
-tg_file.write("{},{},{},{},{},{},{},{}\n".format(t.dec_id,hex_val,t.mode,alpha,description,service_type,home_site,systemid,t.priority))
+tg_file.write("{},{},{},{},{},{},{},{},{}\n".format(t.dec_id,hex_val,t.mode,alpha,description,service_type,home_site,systemid,t.priority))
 

--- a/radio/management/commands/export_talkgroups.py
+++ b/radio/management/commands/export_talkgroups.py
@@ -60,6 +60,5 @@ def export_tg_file(self, options):
             systemid = ''
             if(t.system_id):
                 systemid = t.system_id
-
-tg_file.write("{},{},{},{},{},{},{},{},{}\n".format(t.dec_id,hex_val,t.mode,alpha,description,service_type,home_site,systemid,t.priority))
+            tg_file.write("{},{},{},{},{},{},{},{},{}\n".format(t.dec_id,hex_val,t.mode,alpha,description,service_type,home_site,systemid,t.priority))
 

--- a/radio/management/commands/export_talkgroups.py
+++ b/radio/management/commands/export_talkgroups.py
@@ -57,5 +57,9 @@ def export_tg_file(self, options):
             home_site = ''
             if(t.home_site):
                 home_site = t.home_site
-            tg_file.write("{},{},{},{},{},{},{},{}\n".format(t.dec_id,hex_val,t.mode,alpha,description,service_type,home_site,t.priority))
+            systemid = ''
+            if(t.system_id):
+                systemid = t.system_id
+
+tg_file.write("{},{},{},{},{},{},{},{}\n".format(t.dec_id,hex_val,t.mode,alpha,description,service_type,home_site,systemid,t.priority))
 

--- a/radio/management/commands/prune_database.py
+++ b/radio/management/commands/prune_database.py
@@ -44,7 +44,7 @@ def purge_trans(options):
         days_opt = 0
         days_default = True
 
-    t = Transmission.objects.filter(start_datetime__lt=datetime.now() - timedelta(days=days_opt))
+    t = Transmission.objects.filter(start_datetime__lt=datetime.now(tz=timezone.utc) - timedelta(days=days_opt))
     print('Pruning %s transmissions older than %s days.' % (t.count(), days_opt))
     t.delete()
     print('Pruning complete')


### PR DESCRIPTION
Also some "edits" from export_talkgroups.py that I forgot to roll back before committing the prune_database.py.  The changes to export_talkgroups.py result in just whitespace changes, as I was tinkering with the file to get the export to line up more with radio reference, and apparently put it back.


