### PR TITLE
Update djangorestframework requirement to fix ScanOC/trunk-player#86

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ django-allauth==0.34.0
 django-appconf==1.0.2
 django-redis==4.8.0
 django-select2==6.0.1
-djangorestframework>=3.9.1
+djangorestframework<3.12
 hyperlink==17.3.1
 idna==2.8
 incremental==17.5.0


### PR DESCRIPTION
Fixes issue ScanOC/trunk-player#86 by preventing pip from pulling 3.12 branch of djangorestframework which dropped support for django 1.11. 