### PR TITLE
fixed Docker Image and added RadioRefrence TG import

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.9
 RUN apt-get update && \
     apt-get -y install nginx redis-server ssl-cert tzdata && \
     rm -rf /var/lib/apt/lists/* 

--- a/radio/management/commands/import_talkgroups.py
+++ b/radio/management/commands/import_talkgroups.py
@@ -26,6 +26,13 @@ class Command(BaseCommand):
             help='Truncat any data that would not fit into the DB',
             default=True,
        )
+        parser.add_argument(
+            '--rr',
+            dest='rr',
+            action='store_true',
+            help='Import in Radio Refrence Format',
+            default=True,
+       )
 
     def handle(self, *args, **options):
         import_tg_file(self, options)
@@ -36,6 +43,7 @@ def import_tg_file(self, options):
     file_name = options['file']
     system_id = options['system']
     truncate = options['truncate']
+    rrFormat = options['rr']
     try:
         system = System.objects.get(pk=system_id)
     except System.DoesNotExist:
@@ -51,33 +59,55 @@ def import_tg_file(self, options):
     with open(file_name) as tg_file:
         tg_info = csv.reader(tg_file, delimiter=',', quotechar='"')
         line_number = 0
-        for row in tg_info:
-            line_number+=1
-            try:
-                if truncate:
-                    if len(row[2]) > mode_max_length:
-                      row[2] = row[2][:mode_max_length]
-                      self.stdout.write("Truncating mode from line ({}) TG {}".format(line_number, row[3]))
-                    if len(row[3]) > alpha_tag_max_length:
-                      row[3] = row[3][:alpha_tag_max_length]
-                      self.stdout.write("Truncating alpha_tag from line ({}) TG {}".format(line_number, row[3]))
-                    if len(row[4]) > description_max_length:
-                      row[4] = row[4][:description_max_length]
-                      self.stdout.write("Truncating description from line ({}) TG {}".format(line_number, row[3]))
-                #print('LEN ' + str(len(row)))
-                priority = 3
+        if not rrFormat:
+            for row in tg_info:
+                line_number+=1
                 try:
-                    priority = row[6]
-                except IndexError:
-                    pass
-                try:
-                    priority = int(priority)
-                except ValueError:
+                    if truncate:
+                        if len(row[2]) > mode_max_length:
+                            row[2] = row[2][:mode_max_length]
+                            self.stdout.write("Truncating mode from line ({}) TG {}".format(line_number, row[3]))
+                        if len(row[3]) > alpha_tag_max_length:
+                            row[3] = row[3][:alpha_tag_max_length]
+                            self.stdout.write("Truncating alpha_tag from line ({}) TG {}".format(line_number, row[3]))
+                        if len(row[4]) > description_max_length:
+                            row[4] = row[4][:description_max_length]
+                            self.stdout.write("Truncating description from line ({}) TG {}".format(line_number, row[3]))
+                    #print('LEN ' + str(len(row)))
                     priority = 3
-                obj, create = TalkGroup.objects.update_or_create(dec_id=row[0], system=system, defaults={'mode': row[2], 'alpha_tag': row[3], 'description': row[4], 'priority': priority})
-                obj.service_type = row[5][:20]
-                obj.save()
-            except (IntegrityError, IndexError):
-                pass
-                #print("Skipping {}".format(row[3]))
-
+                    try:
+                        priority = row[7]
+                    except IndexError:
+                        pass
+                    try:
+                        priority = int(priority)
+                    except ValueError:
+                        priority = 3
+                    obj, create = TalkGroup.objects.update_or_create(dec_id=row[0], system=system, defaults={'mode': row[2], 'alpha_tag': row[3], 'description': row[4], 'priority': priority})
+                    obj.service_type = row[5][:20]
+                    obj.save()
+                except (IntegrityError, IndexError):
+                    pass
+                    #print("Skipping {}".format(row[3]))
+        else:
+            for row in tg_info:
+                line_number+=1
+                try:
+                    if truncate:
+                        if len(row[3]) > mode_max_length:
+                            row[3] = row[3][:mode_max_length]
+                            self.stdout.write("Truncating mode from line ({}) TG {}".format(line_number, row[2]))
+                        if len(row[2]) > alpha_tag_max_length:
+                            row[2] = row[2][:alpha_tag_max_length]
+                            self.stdout.write("Truncating alpha_tag from line ({}) TG {}".format(line_number, row[2]))
+                        if len(row[4]) > description_max_length:
+                            row[4] = row[4][:description_max_length]
+                            self.stdout.write("Truncating description from line ({}) TG {}".format(line_number, row[2]))
+                    #print('LEN ' + str(len(row)))
+                    priority = 3
+                    obj, create = TalkGroup.objects.update_or_create(dec_id=row[0], system=system, defaults={'mode': row[3], 'alpha_tag': row[2], 'description': row[4], 'priority': priority})
+                    obj.service_type = row[5][:20]
+                    obj.save()
+                except (IntegrityError, IndexError, ValueError):
+                    pass
+                    #print("Skipping {}".format(row[3]))


### PR DESCRIPTION
# RELEASE v0.1.3

- Fixes docker image tag for python
- Adds support for Radio Reference format Talkgroup import
    - use `--rr` to import stright from radio reference 
    - `./manage.py import_talkgroups --system 0 --rr test.csv`

## Upgade Instructions
1. `git pull`
2. Restart Trunk-Player