### PR TITLE
Update listening IP for daphne so that nginx reverse proxies don't break.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,5 +21,5 @@ echo "daphne"
 ./manage.py runworker livecall-scan-default > runworker2.log 2>&1 &
 ./manage.py runworker livecall-scan-default > runworker3.log 2>&1 &
 ./manage.py runworker livecall-scan-default > runworker4.log 2>&1 &
-daphne trunk_player.asgi:channel_layer --port 7055 --bind 127.0.0.1 --access-log /var/log/trunk-player/daphne_main.log --ping-interval 3 --ping-timeout 12 --proxy-headers
+daphne trunk_player.asgi:channel_layer --port 7055 --bind 0.0.0.0 --access-log /var/log/trunk-player/daphne_main.log --ping-interval 3 --ping-timeout 12 --proxy-headers
 #exec "$@"

--- a/trunk_player/supervisor.conf.sample
+++ b/trunk_player/supervisor.conf.sample
@@ -1,17 +1,36 @@
 # supervisor.conf
 ## Ensure you edit directory paths and user= varibles in this file to your installation path and user.
+## Typical user is: radio
+## Typical installation is: /home/radio/trunk-player/
+
+# Logging:
+## It is advisable to modify all stdout_logfile's to /var/log/trunk-player/ versus the defaults below.
+## You can then set logrotate settings accordingly rather having one expansively huge file. 
+##    mkdir -p /var/log/trunk-player;chown radio:radio /var/log/trunk-player;chmod 755 /var/log/trunk-player
+
+# trunkplayer_asgi_workers note:
+## Set numprocs under program:trunkplayer_asgi_workers to a value higher than 4 for large sites/systems. 
+##    For high activity systems, a value of 10 or more is a sane starting value. Try to not exceed two 
+##    or three workers per CPU unless you enjoy watching your CPU's do work under high activity. 
+
+# trunkplayer_asgi_daphne note:
+##    Do not set trunkplayer_asgi_daphne to have more than one process. 
+
+# trunkplayer_add_transmission_workers note:
+## Depending on system configuration, this particular worker can sometimes be disabled.
+## Most configurations utilize SSH/SCP/rsync currently. This may change in the future! 
+
 
 [group:trunkplayer]
 programs=trunkplayer_asgi_daphne, trunkplayer_asgi_workers, trunkplayer_add_transmission_workers
 priority=999
-
 
 [program:trunkplayer_asgi_daphne]
 user=radio
 redirect_stderr=true
 stdout_logfile=/home/radio/trunk-player/logs/daphne.log
 directory=/home/radio/trunk-player
-command=/home/radio/trunk-player/env/bin/daphne -u daphne trunk_player.asgi:channel_layer --port 7055 --bind 127.0.0.1 --access-log /var/log/trunk-player/daphne_main.log --ping-interval 3 --ping-timeout 12 --proxy-headers
+command=/home/radio/trunk-player/env/bin/daphne -u daphne trunk_player.asgi:channel_layer --port 7055 --bind 0.0.0.0 --access-log /var/log/trunk-player/daphne_main.log --ping-interval 3 --ping-timeout 12 --proxy-headers
 
 [program:trunkplayer_asgi_workers]
 user=radio


### PR DESCRIPTION
- Added notes on supervisor config stuff.
- Modified the `--bind` segments on `entrypoint.sh` and `supervisor.conf.sample` from `127.0.0.1` to `0.0.0.0`. 

Worth noting that setting the binding IP to `0.0.0.0` effectively binds to **_all_** interfaces. This may (read: probably will) pose a security risk if port 7055 is not properly filtered or firewalled on the machine. If the daphne daemon is behind a NAT, this is a non-issue. Documentation may need to be updated for this change. 